### PR TITLE
Fix a bug in the creation of options array. The bug appears only with so...

### DIFF
--- a/cpt-yahsp/src/options.cpp
+++ b/cpt-yahsp/src/options.cpp
@@ -138,7 +138,7 @@ void cmd_line(int argc, const char **argv)
 {
   nb_options = sizeof(long_options) / sizeof(OptItem);
   struct option options[nb_options * 2 + 1];
-  char arg_string[nb_options + 1];
+  char arg_string[nb_options * 2 + 1];
   int c, i, j = 0, k = 0;
 
   for(i = 0; i < nb_options; i++) {


### PR DESCRIPTION
Fix a bug in the creation of options array. The bug appears only with some compilers and was due to the fact that the arg_string was not allocated properly, according to the number of possible options, causing a segfault using getopt_long_only.
